### PR TITLE
可以通过环境变量控制模型存储位置

### DIFF
--- a/app/download_models.py
+++ b/app/download_models.py
@@ -1,21 +1,44 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-FunASR模型下载脚本
+FunASR 模型下载脚本
 并行下载所有模型文件
 """
 import logging
 import sys
 import json
 import threading
+import os
+from pathlib import Path
 from app.funasr_config import MODEL_REVISION, get_models_for_download
 from app.logging_config import setup_logging
 
 logger = logging.getLogger(__name__)
 
 
+def get_custom_model_dir(model_type):
+    """
+    获取自定义模型目录
+    优先级：FUNASR_MODEL_DIR 环境变量 > 用户主目录/.vocotype/models
+    """
+    # 1. 检查环境变量（最高优先级）
+    custom_dir = os.environ.get("FUNASR_MODEL_DIR")
+    if custom_dir:
+        logger.info(f"检测到模型目录环境变量：{custom_dir}")
+        model_dir = Path(custom_dir) / model_type
+        model_dir.mkdir(parents=True, exist_ok=True)
+        return model_dir
+
+    # 2. 使用用户主目录下的固定位置（打包后也稳定）
+    #    Windows: C:\Users\<用户名>\.vocotype\models
+    home = Path.home()
+    model_dir = home / ".vocotype" / "models" / model_type
+    model_dir.mkdir(parents=True, exist_ok=True)
+    return model_dir
+
+
 def download_model(model_config, progress_callback=None):
-    """下载单个模型（使用 modelscope.snapshot_download，无需 funasr/torch）"""
+    """下载单个模型（使用 modelscope.snapshot_download，支持自定义目录）"""
     model_name = model_config["name"]
     model_type = model_config["type"]
 
@@ -25,13 +48,20 @@ def download_model(model_config, progress_callback=None):
         if progress_callback:
             progress_callback(model_type, "downloading", 0)
 
-        # 下载到本地缓存目录
-        snapshot_download(model_name, revision=MODEL_REVISION)
+        # 获取自定义模型目录
+        model_dir = get_custom_model_dir(model_type)
+
+        # 下载到自定义目录
+        snapshot_download(
+            model_name,
+            revision=MODEL_REVISION,
+            local_dir=str(model_dir)
+        )
 
         if progress_callback:
             progress_callback(model_type, "completed", 100)
 
-        return {"success": True, "model": model_type}
+        return {"success": True, "model": model_type, "path": str(model_dir)}
 
     except Exception as e:
         if progress_callback:
@@ -45,10 +75,10 @@ def main():
     project_root = os.path.dirname(os.path.abspath(__file__))
     log_dir = os.path.join(project_root, "logs")
     setup_logging("INFO", log_dir)
-    
+
     # 从统一配置获取模型列表
     models = get_models_for_download()
-    
+
     # 进度跟踪
     progress = {"asr": 0, "vad": 0, "punc": 0}
     results = {}
@@ -56,10 +86,10 @@ def main():
     total_count = len(models)
     count_lock = threading.Lock()  # 添加锁保护计数器
     results_lock = threading.Lock()
-    
+
     def progress_callback(model_type, stage, percent, error=None):
         nonlocal completed_count
-        
+
         # 使用锁保护共享变量的修改
         with count_lock:
             if stage == "downloading":
@@ -70,12 +100,12 @@ def main():
             elif stage == "error":
                 progress[model_type] = 0
                 completed_count += 1
-            
+
             # 计算总体进度
             overall_progress = sum(progress.values()) / total_count
             current_completed = completed_count
-        
-        # 输出进度信息（在锁外执行I/O操作）
+
+        # 输出进度信息（在锁外执行 I/O 操作）
         status = {
             "stage": stage,
             "model": model_type,
@@ -84,13 +114,13 @@ def main():
             "completed": current_completed,
             "total": total_count
         }
-        
+
         if error:
             status["error"] = error
-            
+
         print(json.dumps(status, ensure_ascii=False))
         sys.stdout.flush()
-    
+
     # 启动并行下载线程
     threads = []
     for model_config in models:
@@ -102,18 +132,18 @@ def main():
         thread = threading.Thread(target=worker, daemon=True)
         thread.start()
         threads.append(thread)
-    
+
     # 等待所有线程完成
     for thread in threads:
         thread.join()
-    
+
     # 检查结果
     failed_models = [model_type for model_type, result in results.items() if not result["success"]]
-    
+
     if failed_models:
         final_result = {
             "success": False,
-            "error": f"以下模型下载失败: {', '.join(failed_models)}",
+            "error": f"以下模型下载失败：{', '.join(failed_models)}",
             "failed_models": failed_models,
             "results": results
         }
@@ -123,7 +153,7 @@ def main():
             "message": "所有模型下载完成",
             "results": results
         }
-    
+
     print(json.dumps(final_result, ensure_ascii=False))
     sys.stdout.flush()
 
@@ -141,52 +171,61 @@ if __name__ == "__main__":
 
 def get_model_cache_path(model_name, revision):
     """
-    离线优先获取模型路径
-    1. 先检查本地缓存是否存在且完整
-    2. 如果本地存在，直接返回路径（避免联网）
-    3. 如果不存在，才调用 snapshot_download 进行下载
+    获取模型路径（支持自定义目录）
+    1. 先检查自定义目录是否存在模型文件
+    2. 如果存在，直接返回路径
+    3. 如果不存在，调用 snapshot_download 进行下载到自定义目录
     """
-    from pathlib import Path
-
-    # 构建本地缓存路径（与Rust端保持一致）
-    home = Path.home()
-    cache_base = home / ".cache" / "modelscope" / "hub" / "models" / "iic"
-
     # 从完整模型名提取简短名称 (iic/xxx -> xxx)
     short_name = model_name.split('/')[-1] if '/' in model_name else model_name
-    model_dir = cache_base / short_name
 
-    # 检查模型是否已缓存
-    if model_dir.exists():
-        quant_file = model_dir / "model_quant.onnx"
-        base_file = model_dir / "model.onnx"
+    # 获取自定义模型目录（按模型类型分类）
+    model_type_map = {
+        "asr": "asr",
+        "vad": "vad",
+        "punc": "punc"
+    }
+    model_type = "asr"  # 默认
+    for key, value in model_type_map.items():
+        if key in short_name or (key == "asr" and "paraformer" in short_name):
+            model_type = value
+            break
 
-        # 只要有一个模型文件存在，就认为缓存有效
-        if quant_file.exists() or base_file.exists():
-            logger.info(f"使用本地缓存模型: {model_dir}")
-            return str(model_dir)
+    # 优先使用自定义目录
+    model_dir = get_custom_model_dir(model_type)
+
+    # 检查模型文件是否存在
+    quant_file = model_dir / "model_quant.onnx"
+    base_file = model_dir / "model.onnx"
+
+    # 只要有一个模型文件存在，就认为缓存有效
+    if quant_file.exists() or base_file.exists():
+        logger.info(f"使用本地模型：{model_dir}")
+        return str(model_dir)
 
     # 本地不存在，需要下载
-    logger.info(f"本地缓存不存在，开始下载模型: {model_name}")
+    logger.info(f"本地模型不存在，开始下载模型：{model_name}")
     from modelscope.hub.snapshot_download import snapshot_download
 
-    # 使用 ignore_file_pattern 和 local_files_only 参数控制行为
+    # 直接下载到自定义目录（不再使用离线模式回退）
     try:
-        # 先尝试纯离线模式（不联网）
-        model_dir = snapshot_download(
+        snapshot_download(
             model_name,
             revision=revision,
-            local_files_only=True  # 仅使用本地文件，不联网
+            local_dir=str(model_dir)
         )
-        logger.info(f"使用已下载的模型（离线模式）: {model_dir}")
-        return model_dir
-    except Exception as offline_error:
-        logger.warning(f"离线模式失败: {offline_error}，尝试在线下载")
-
-        # 离线失败，进行在线下载
-        model_dir = snapshot_download(
-            model_name,
-            revision=revision,
-        )
-        logger.info(f"模型下载完成: {model_dir}")
-        return model_dir
+        logger.info(f"模型下载完成到自定义目录：{model_dir}")
+        return str(model_dir)
+    except Exception as e:
+        logger.error(f"模型下载失败：{e}")
+        # 下载失败时，尝试使用默认缓存路径作为后备
+        try:
+            fallback_dir = snapshot_download(
+                model_name,
+                revision=revision,
+            )
+            logger.info(f"使用默认缓存路径作为后备：{fallback_dir}")
+            return fallback_dir
+        except Exception as fallback_error:
+            logger.error(f"后备下载也失败：{fallback_error}")
+            raise

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,42 @@ python main.py --save-dataset
 
 > **模型下载**：首次运行时，程序会自动下载约 500MB 的模型文件，请确保网络连接稳定。
 
+### 📁 模型存储位置
+
+模型文件默认下载到用户主目录下的固定位置：
+
+| 操作系统 | 默认模型路径 |
+|---------|-------------|
+| **Windows** | `C:\Users\<用户名>\.vocotype\models\` |
+| **macOS/Linux** | `~/.vocotype/models/` |
+
+模型按类型分类存储：
+```
+.vocotype/
+└── models/
+    ├── asr/      # ASR 语音识别模型
+    ├── vad/      # VAD 语音活动检测模型
+    └── punc/     # 标点恢复模型
+```
+
+**自定义模型存储位置**
+
+如需更改存储位置，可通过设置环境变量 `FUNASR_MODEL_DIR`：
+
+```bash
+# Windows PowerShell
+$env:FUNASR_MODEL_DIR="D:\my-models"
+python main.py
+
+# Windows CMD
+set FUNASR_MODEL_DIR=D:\my-models
+python main.py
+
+# macOS/Linux
+export FUNASR_MODEL_DIR=/path/to/models
+python main.py
+```
+
 ## 🌐 Volcengine 火山引擎 BigASR 流式识别后端（可选）
 
 除了默认的本地 FunASR 离线引擎，VocoType CLI 还支持接入[火山引擎豆包大模型流式语音识别](https://www.volcengine.com/docs/6561/1354869)作为云端识别后端。


### PR DESCRIPTION
### 📁 模型存储位置

模型文件默认下载到用户主目录下的固定位置：

| 操作系统 | 默认模型路径 |
|---------|-------------|
| **Windows** | `C:\Users\<用户名>\.vocotype\models\` |
| **macOS/Linux** | `~/.vocotype/models/` |

模型按类型分类存储：
```
.vocotype/
└── models/
    ├── asr/      # ASR 语音识别模型
    ├── vad/      # VAD 语音活动检测模型
    └── punc/     # 标点恢复模型
```

**自定义模型存储位置**

如需更改存储位置，可通过设置环境变量 `FUNASR_MODEL_DIR`：

```bash
# Windows PowerShell
$env:FUNASR_MODEL_DIR="D:\my-models"
python main.py

# Windows CMD
set FUNASR_MODEL_DIR=D:\my-models
python main.py

# macOS/Linux
export FUNASR_MODEL_DIR=/path/to/models
python main.py
```